### PR TITLE
fix: dont concat with default extensions

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = function PurifyPlugin(options) {
     // We are not opinionated...
     var exts = ["js"];
     options.scanForExts = options.scanForExts || [];
-    this.scanForExts = merge(exts, options.scanForExts);
+    this.scanForExts = (options.scanForExts || ["js"]);
 }
 
 module.exports.prototype.apply = function(compiler) {

--- a/index.js
+++ b/index.js
@@ -18,8 +18,6 @@ module.exports = function PurifyPlugin(options) {
     this.paths = options.paths || [];
     // Additional extensions to scan for. This is kept minimal, for obvious reasons.
     // We are not opinionated...
-    var exts = ["js"];
-    options.scanForExts = options.scanForExts || [];
     this.scanForExts = (options.scanForExts || ["js"]);
 }
 


### PR DESCRIPTION
If the user doesn't want `js` files to be included we should not concat with default extensions types.