### PR TITLE
Consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ And, that's it! Your scripts and view files will be scanned for classes, and tho
 ## Options
 This plugin, unlike the original PurifyCSS plugin, provides special features, such as scanning the dependency files and all kinds of files. To configure such behaviours, I will show you the options.
 
-| Property      | Description
-|---------------|------------
-| `basePath`    | The path from which all the other paths will start. Required.
-| `scanForExts` | An array of extensions that should be given to PurifyCSS when determining classes. Defaults to: `.js`
-| `paths`       | An array of globs that reveal all your files. See [glob](http://npmjs.org/glob)'s documentation to see what kind of paths you can pass in this array. Use this array to pass files that won't be known to WebPack.
+| Property            | Description
+|---------------------|------------
+| `basePath`          | The path from which all the other paths will start. Required.
+| `resolveExtensions` | An array of extensions that should be given to PurifyCSS when determining classes. Defaults to: `.js`
+| `paths`             | An array of globs that reveal all your files. See [glob](http://npmjs.org/glob)'s documentation to see what kind of paths you can pass in this array. Use this array to pass files that won't be known to WebPack.
 
 ## Notes
 This plugin is NOT a fork of [the offical plugin](https://github.com/purifycss/purifycss-webpack-plugin)! Instead, this is it's own. I prefixed it with `bird3`, since it was created within my [BIRD3](https://github.com/DragonsInn/BIRD3) project and to make an obvious separation to the offical version.

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = function PurifyPlugin(options) {
     this.paths = options.paths || [];
     // Additional extensions to scan for. This is kept minimal, for obvious reasons.
     // We are not opinionated...
-    this.scanForExts = (options.scanForExts || ["js"]);
+    this.resolveExtensions = (options.resolverExtensions || [".js"]);
 }
 
 module.exports.prototype.apply = function(compiler) {
@@ -27,8 +27,8 @@ module.exports.prototype.apply = function(compiler) {
             // Look for additional JS/HTML stuff.
             for(var key in compilation.fileDependencies) {
                 var file = compilation.fileDependencies[key];
-                var ext = path.extname(file).substr(1);
-                if (self.scanForExts.indexOf(ext) > -1) files.push(file);
+                var ext = path.extname(file);
+                if (self.resolveExtensions.indexOf(ext) > -1) files.push(file);
             }
 
             // Look for purifyable CSs...

--- a/index.js
+++ b/index.js
@@ -3,12 +3,6 @@ var glob = require("glob").sync;
 var path = require("path");
 var ConcatSource = require("webpack/lib/ConcatSource");
 
-function merge() {
-    var base = [];
-    base = base.concat.apply(base, arguments);
-    return base;
-}
-
 module.exports = function PurifyPlugin(options) {
     // Base path
     this.basePath = options.basePath || process.cwd();
@@ -22,10 +16,11 @@ module.exports = function PurifyPlugin(options) {
 }
 
 module.exports.prototype.apply = function(compiler) {
-    var files=[], self=this;
-    self.paths.forEach(function(p){
-        files = merge(files, glob(path.join(self.basePath, p)));
-    });
+    var self = this;
+
+    var files = self.paths.reduce(function(results, p) {
+      return results.concat(glob(path.join(self.basePath, p)));
+    }, []);
 
     compiler.plugin("this-compilation", function(compilation) {
         compilation.plugin("additional-assets", function(cb){


### PR DESCRIPTION
* refactor: use`Array.reduce`
* call options `resolveExtensions` like webpack config option (https://webpack.github.io/docs/configuration.html#resolve-extensions)

I'd like to change `this.basePath` to `cwd` like `process.cwd` or `child_process.exec/fork/spawn` option. What are you thoughts?