### PR TITLE
Defaults resolveExtensions to webpack ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ This plugin, unlike the original PurifyCSS plugin, provides special features, su
 | Property            | Description
 |---------------------|------------
 | `basePath`          | The path from which all the other paths will start. Required.
-| `resolveExtensions` | An array of extensions that should be given to PurifyCSS when determining classes. Defaults to: `.js`
+| `resolveExtensions` | An array of extensions that should be given to PurifyCSS when determining classes. (defaults to webpack `resolve.extensions` config)
 | `paths`             | An array of globs that reveal all your files. See [glob](http://npmjs.org/glob)'s documentation to see what kind of paths you can pass in this array. Use this array to pass files that won't be known to WebPack.
 | `purifyOptions`     | Pass these options to PurifyCSS. See [here](https://github.com/purifycss/purifycss#options-optional). Note: `output` is always `false`.
 

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ module.exports.prototype.apply = function(compiler) {
         self.paths = self.userOptions.paths || [];
         // Additional extensions to scan for. This is kept minimal, for obvious reasons.
         // We are not opinionated...
-        self.resolveExtensions = (self.userOptions.resolverExtensions || [".js"]);
+        self.resolveExtensions = self.userOptions.resolveExtensions || compiler.options.resolve.extensions;
 
         var files = self.paths.reduce(function(results, p) {
           return results.concat(glob(path.join(self.basePath, p)));


### PR DESCRIPTION
- fixes also the typo in the var (resolve**r**Extensions)
- uses webpack config `resolve.extensions` as defaults for `resolveExtensions
